### PR TITLE
Feat/setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,6 @@ import { TechnologyPanel } from '@/components/TechnologyPanel'
 import { WorkshopPanel } from '@/components/WorkshopPanel'
 import { LogPanel } from '@/components/LogPanel'
 import { SettingsPanel } from '@/components/SettingsPanel'
-import { Sheet, SheetTrigger, SheetContent } from '@/components/ui/sheet'
-import { Settings2 } from 'lucide-react'
 import { AUTO_SAVE_INTERVAL_TICKS, GAME_TICK_INTERVAL_MS } from '@/engine/constants'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -43,7 +41,9 @@ function PlaceholderActionPanel(props: {
       </CardHeader>
       <CardContent className="flex flex-wrap items-center gap-3">
         <Button disabled={locked}>{buttonLabel}</Button>
-        {requirement ? <span className="text-sm text-muted-foreground">前置条件: {requirement}</span> : null}
+        {requirement ? (
+          <span className="text-sm text-muted-foreground">前置条件: {requirement}</span>
+        ) : null}
       </CardContent>
     </Card>
   )
@@ -101,22 +101,11 @@ function App() {
               <span>Ticks: {gameState.tickCount}</span>
               <span>TPS: ~5</span>
               <LogPanel />
-              <Sheet>
-                <SheetTrigger asChild>
-                  <Button variant="ghost" size="icon" aria-label="游戏设置">
-                    <Settings2 className="size-5" />
-                  </Button>
-                </SheetTrigger>
-                <SheetContent side="right" className="max-w-xs w-full">
-                  <SettingsPanel />
-                </SheetContent>
-              </Sheet>
+              <SettingsPanel />
             </div>
           </div>
         </header>
-
         <div className="px-4 py-4">
-
           <Tabs defaultValue="buildings" className="gap-4">
             <TabsList variant="line" className="w-full justify-start overflow-x-auto">
               <TabsTrigger value="buildings">建筑</TabsTrigger>
@@ -173,7 +162,9 @@ function App() {
           </Tabs>
 
           <Card className="mt-4">
-            <CardContent className="pt-6 text-xs text-muted-foreground">💾 游戏会自动保存到浏览器存储。</CardContent>
+            <CardContent className="pt-6 text-xs text-muted-foreground">
+              💾 游戏会自动保存到浏览器存储。
+            </CardContent>
           </Card>
         </div>
       </SidebarInset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,9 @@ import { BuildingPanel } from '@/components/BuildingPanel'
 import { JobPanel } from '@/components/JobPanel'
 import { TechnologyPanel } from '@/components/TechnologyPanel'
 import { LogPanel } from '@/components/LogPanel'
+import { SettingsPanel } from '@/components/SettingsPanel'
+import { Sheet, SheetTrigger, SheetContent } from '@/components/ui/sheet'
+import { Settings2 } from 'lucide-react'
 import { AUTO_SAVE_INTERVAL_TICKS, GAME_TICK_INTERVAL_MS } from '@/engine/constants'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -95,14 +98,22 @@ function App() {
               <span>Ticks: {gameState.tickCount}</span>
               <span>TPS: ~5</span>
               <LogPanel />
-              <Button variant="outline" onClick={resetGame}>
-                🔄 重置游戏
-              </Button>
+              <Sheet>
+                <SheetTrigger asChild>
+                  <Button variant="ghost" size="icon" aria-label="游戏设置">
+                    <Settings2 className="size-5" />
+                  </Button>
+                </SheetTrigger>
+                <SheetContent side="right" className="max-w-xs w-full">
+                  <SettingsPanel />
+                </SheetContent>
+              </Sheet>
             </div>
           </div>
         </header>
 
         <div className="px-4 py-4">
+
           <Tabs defaultValue="buildings" className="gap-4">
             <TabsList variant="line" className="w-full justify-start overflow-x-auto">
               <TabsTrigger value="buildings">建筑</TabsTrigger>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,6 @@ function App() {
   const tick = useGameStore((store) => store.tick)
   const gameState = useGameStore((store) => store.gameState)
   const saveGame = useGameStore((store) => store.saveGame)
-  const resetGame = useGameStore((store) => store.resetGame)
   const gameTickRef = useRef(0)
 
   useEffect(() => {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -40,7 +40,7 @@ export function SettingsPanel() {
           localStorage.setItem(SAVE_KEY, text)
           loadGame()
           window.location.reload()
-        } catch (err) {
+        } catch {
           window.alert('导入失败：存档文件格式不正确')
         }
       }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,6 +1,8 @@
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useGameStore } from '@/store/gameStore'
+import type { ChangeEvent } from 'react'
+import { SAVE_KEY } from '@/engine/save'
 
 export function SettingsPanel() {
   const resetGame = useGameStore((store) => store.resetGame)
@@ -10,7 +12,7 @@ export function SettingsPanel() {
   // 导出存档 
   const handleExport = () => {
     saveGame()
-    const data = localStorage.getItem('puppies-game-save')
+    const data = localStorage.getItem(SAVE_KEY)
     if (data) {
       const blob = new Blob([data], { type: 'application/json' })
       const url = URL.createObjectURL(blob)
@@ -23,16 +25,24 @@ export function SettingsPanel() {
   }
 
   // 导入存档
-  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImport = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
     const reader = new FileReader()
     reader.onload = (event) => {
       const text = event.target?.result as string
       if (text) {
-        localStorage.setItem('puppies-game-save', text)
-        loadGame()
-        window.location.reload()
+        try {
+          const data = JSON.parse(text)
+          if (!data || typeof data !== 'object' || !('resourceCounts' in data)) {
+            throw new Error('存档格式不正确')
+          }
+          localStorage.setItem(SAVE_KEY, text)
+          loadGame()
+          window.location.reload()
+        } catch (err) {
+          window.alert('导入失败：存档文件格式不正确')
+        }
       }
     }
     reader.readAsText(file)

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,15 +1,15 @@
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useGameStore } from '@/store/gameStore'
 import type { ChangeEvent } from 'react'
 import { SAVE_KEY } from '@/engine/save'
-
+import { toast } from 'sonner'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 export function SettingsPanel() {
   const resetGame = useGameStore((store) => store.resetGame)
   const saveGame = useGameStore((store) => store.saveGame)
   const loadGame = useGameStore((store) => store.loadGame)
 
-  // 导出存档 
+  // 导出存档
   const handleExport = () => {
     saveGame()
     const data = localStorage.getItem(SAVE_KEY)
@@ -39,9 +39,9 @@ export function SettingsPanel() {
           }
           localStorage.setItem(SAVE_KEY, text)
           loadGame()
-          window.location.reload()
+          toast.success('存档导入成功')
         } catch {
-          window.alert('导入失败：存档文件格式不正确')
+          toast.error('导入失败：存档文件格式不正确')
         }
       }
     }
@@ -49,22 +49,35 @@ export function SettingsPanel() {
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>设置</CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
-        <div className="flex flex-col gap-2">
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="游戏设置">
+          ⚙️
+        </Button>
+      </SheetTrigger>
+
+      <SheetContent side="right" className="max-w-xs w-full">
+        <SheetHeader>
+          <SheetTitle>设置</SheetTitle>
+        </SheetHeader>
+
+        <div className="flex flex-col gap-3 mt-6">
           <Button variant="outline" asChild className="w-full">
-            <label className="w-full block cursor-pointer text-center">
+            <label className="w-full cursor-pointer text-center">
               导入存档
-              <input type="file" accept="application/json" style={{ display: 'none' }} onChange={handleImport} />
+              <input type="file" accept="application/json" hidden onChange={handleImport} />
             </label>
           </Button>
-          <Button variant="outline" onClick={handleExport} className="w-full">导出存档</Button>
-          <Button variant="destructive" onClick={resetGame} className="w-full">重置游戏</Button>
+
+          <Button variant="outline" onClick={handleExport} className="w-full">
+            导出存档
+          </Button>
+
+          <Button variant="destructive" onClick={resetGame} className="w-full">
+            重置游戏
+          </Button>
         </div>
-      </CardContent>
-    </Card>
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,0 +1,60 @@
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useGameStore } from '@/store/gameStore'
+
+export function SettingsPanel() {
+  const resetGame = useGameStore((store) => store.resetGame)
+  const saveGame = useGameStore((store) => store.saveGame)
+  const loadGame = useGameStore((store) => store.loadGame)
+
+  // 导出存档 
+  const handleExport = () => {
+    saveGame()
+    const data = localStorage.getItem('puppies-game-save')
+    if (data) {
+      const blob = new Blob([data], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'puppies-game-save.json'
+      a.click()
+      URL.revokeObjectURL(url)
+    }
+  }
+
+  // 导入存档
+  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = (event) => {
+      const text = event.target?.result as string
+      if (text) {
+        localStorage.setItem('puppies-game-save', text)
+        loadGame()
+        window.location.reload()
+      }
+    }
+    reader.readAsText(file)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>设置</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <Button variant="outline" asChild className="w-full">
+            <label className="w-full block cursor-pointer text-center">
+              导入存档
+              <input type="file" accept="application/json" style={{ display: 'none' }} onChange={handleImport} />
+            </label>
+          </Button>
+          <Button variant="outline" onClick={handleExport} className="w-full">导出存档</Button>
+          <Button variant="destructive" onClick={resetGame} className="w-full">重置游戏</Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/engine/gameLoop.ts
+++ b/src/engine/gameLoop.ts
@@ -56,8 +56,6 @@ export function calculatePopulationCap(gameState: GameState): number {
 
 export function calculateResourceLimits(gameState: GameState): Record<string, number> {
   const limits: Record<string, number> = { ...INITIAL_RESOURCE_LIMITS }
-  const { resourceLimitBonuses } = aggregateTechEffects(gameState)
-
   BUILDINGS.forEach((building) => {
     const count = gameState.buildings[building.id] || 0
     if (!building.resourceLimitBonuses || count <= 0) {
@@ -68,10 +66,6 @@ export function calculateResourceLimits(gameState: GameState): Record<string, nu
       limits[resourceId] = (limits[resourceId] || 0) + amount * count
     }
   })
-
-  for (const [resourceId, bonus] of Object.entries(resourceLimitBonuses)) {
-    limits[resourceId] = (limits[resourceId] || 0) + bonus
-  }
 
   return limits
 }

--- a/src/engine/gameLoop.ts
+++ b/src/engine/gameLoop.ts
@@ -76,6 +76,7 @@ export function calculateJobProduction(gameState: GameState): Record<string, num
   RESOURCES.forEach((resource) => {
     production[resource.id] = 0
   })
+  
 
   JOBS.forEach((job) => {
     const assigned = gameState.jobAssignments[job.id] || 0

--- a/src/engine/save.ts
+++ b/src/engine/save.ts
@@ -1,6 +1,6 @@
 import { TECHNOLOGIES, type GameState, createInitialGameState } from '@/engine/types'
 
-const SAVE_KEY = 'puppies-game-save'
+export const SAVE_KEY = 'puppies-game-save'
 
 export function saveGame(gameState: GameState): void {
   const knownTechIds = new Set(TECHNOLOGIES.map((technology) => technology.id))

--- a/src/engine/technologies.test.ts
+++ b/src/engine/technologies.test.ts
@@ -9,6 +9,7 @@ import {
   getUnlockedBuildingsIds,
   getTechnologyById,
   getUnlockedJobsIds,
+  isJobVisible,
   isRequirementSatisfied,
   isTechnologyVisible,
   researchTechnology,
@@ -135,4 +136,23 @@ describe('Technologies', () => {
     const ids = getUnlockedJobsIds(gameState)
     expect(ids.every((id) => JOBS.some((job) => job.id === id))).toBe(true)
   })
+  it('should throw when job does not exist', () => {
+    expect(() => isJobVisible(gameState, 'test')).toThrow('职业 test 不存在')
+  })
+
+  it('should return false when job prerequisites are not satisfied', () => {
+    expect(isJobVisible(gameState, 'scientist')).toBe(false)
+  })
+
+  it('should return true when job prerequisites are satisfied', () => {
+    gameState.buildings.library = 1
+    expect(isJobVisible(gameState, 'scientist')).toBe(true)
+  })
+  it('returns false when any required resource is not enough', () => {
+    gameState.buildings.library = 1
+    gameState.resourceCounts.science = 600
+    gameState.resourceCounts.wood = 199 // woodworking 需要 200
+
+   expect(canResearchTechnology(gameState, 'woodworking')).toBe(false)
+})
 })

--- a/src/engine/technologies.test.ts
+++ b/src/engine/technologies.test.ts
@@ -3,11 +3,16 @@ import { createInitialGameState, type GameState } from '@/engine/types'
 import {
   aggregateTechEffects,
   canResearchTechnology,
+  getTechnologyById,
   getVisibleTechnologiesIds,
+  getUnlockedBuildingsIds,
+  getUnlockedJobsIds,
   isRequirementSatisfied,
+  isTechnologyVisible,
   researchTechnology,
 } from '@/engine/technologies'
 import { getBuildingById, getBuildingCost } from '@/engine/buildings'
+import { BUILDINGS, JOBS } from '@/engine/types'
 
 describe('Technologies', () => {
   let gameState: GameState
@@ -24,9 +29,16 @@ describe('Technologies', () => {
   it('should require enough resources to research visible technology', () => {
     expect(canResearchTechnology(gameState, 'woodworking')).toBe(false)
 
+
     gameState.buildings.library = 1
+    gameState.resourceCounts.science = 99
+    expect(canResearchTechnology(gameState, 'woodworking')).toBe(false)
+
     gameState.resourceCounts.science = 100
     expect(canResearchTechnology(gameState, 'woodworking')).toBe(true)
+
+    gameState.researchedTechIds = ['woodworking']
+    expect(canResearchTechnology(gameState, 'woodworking')).toBe(false)
   })
 
   it('should block research when resources are insufficient', () => {
@@ -51,15 +63,22 @@ describe('Technologies', () => {
 
     gameState.buildings.library = 1
     expect(isRequirementSatisfied(gameState, scientistJob)).toBe(true)
+
+    const requirement = { requiredTechs: ['woodworking'] }
+    expect(isRequirementSatisfied(gameState, requirement)).toBe(false)
+
+    gameState.researchedTechIds = ['woodworking']
+    expect(isRequirementSatisfied(gameState, requirement)).toBe(true)
   })
 
   it('should aggregate all v1 effect types', () => {
     gameState.researchedTechIds = ['woodworking', 'crop_rotation']
-
+    gameState.buildings.library = 2
     const aggregated = aggregateTechEffects(gameState)
     expect(aggregated.buildingCostMultipliers.farm).toBeCloseTo(0.8)
     expect(aggregated.buildingProductionMultipliers.farm).toBeCloseTo(1.2)
     expect(aggregated.jobProductionMultipliers.lumberjack).toBeCloseTo(1.2)
+    expect(aggregated.jobProductionMultipliers.scientist).toBeCloseTo(1.2)
     expect(aggregated.resourceLimitBonuses).toEqual({})
   })
 
@@ -69,5 +88,27 @@ describe('Technologies', () => {
 
     const discountedCost = getBuildingCost(gameState, 'farm')
     expect(discountedCost.food).toBe(Math.ceil((farm.cost.food || 0) * 0.8))
+  })
+
+  it('should return technology if it exists', () => {
+    expect(() => getTechnologyById('test')).toThrow('科技 test 不存在')
+  })
+
+  it('should return technology if it is visible', () => {
+    const tech = getTechnologyById('woodworking')
+    expect(isTechnologyVisible(gameState, tech)).toBe(false)
+
+    gameState.researchedTechIds = ['woodworking']
+    expect(isTechnologyVisible(gameState, tech)).toBe(true)
+  })
+
+  it('should return unlocked building ids', () => {
+    const ids = getUnlockedBuildingsIds(gameState)
+    expect(ids.every((id) => BUILDINGS.some((building) => building.id === id))).toBe(true)
+  })
+
+  it('should return unlocked job ids', () => {
+    const ids = getUnlockedJobsIds(gameState)
+    expect(ids.every((id) => JOBS.some((job) => job.id === id))).toBe(true)
   })
 })

--- a/src/engine/technologies.test.ts
+++ b/src/engine/technologies.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { type GameState } from '@/engine/types'
+import { TECHNOLOGIES, type GameState, type Technology } from '@/engine/types'
 import { createInitialGameState } from '@/engine/initialState'
 import {
   aggregateTechEffects,
@@ -96,15 +96,43 @@ describe('Technologies', () => {
     expect(getVisibleJobsIds(gameState)).toContain('miner')
   })
 
-  it('should aggregate all v1 effect types', () => {
-    gameState.researchedTechIds = ['woodworking', 'crop_rotation']
-    gameState.buildings.library = 2
-    const aggregated = aggregateTechEffects(gameState)
-    expect(aggregated.buildingCostMultipliers.farm).toBeCloseTo(0.8)
-    expect(aggregated.buildingProductionMultipliers.farm).toBeCloseTo(1.2)
-    expect(aggregated.jobProductionMultipliers.lumberjack).toBeCloseTo(1.2)
-    expect(aggregated.jobProductionMultipliers.scientist).toBeCloseTo(1.2)
-    expect(aggregated.resourceLimitBonuses).toEqual({})
+  it('should aggregate additive and multiplier effect modes', () => {
+    const stackingTech: Technology = {
+      id: 'stacking_test_tech',
+      name: 'stacking test',
+      description: 'temporary test technology',
+      cost: {},
+      effects: [
+        {
+          id: 'stacking-test-additive',
+          type: 'job_production',
+          targetId: 'lumberjack',
+          value: 0.1,
+          mode: 'additive',
+        },
+        {
+          id: 'stacking-test-multiplier',
+          type: 'job_production',
+          targetId: 'lumberjack',
+          value: 1.2,
+          mode: 'multiplier',
+        },
+      ],
+    }
+
+    TECHNOLOGIES.push(stackingTech)
+
+    try {
+      gameState.researchedTechIds = ['woodworking', 'crop_rotation', stackingTech.id]
+      gameState.buildings.library = 2
+      const aggregated = aggregateTechEffects(gameState)
+      expect(aggregated.buildingCostMultipliers.farm).toBeCloseTo(0.8)
+      expect(aggregated.buildingProductionMultipliers.farm).toBeCloseTo(1.2)
+      expect(aggregated.jobProductionMultipliers.lumberjack).toBeCloseTo(1.584)
+      expect(aggregated.jobProductionMultipliers.scientist).toBeCloseTo(1.2)
+    } finally {
+      TECHNOLOGIES.pop()
+    }
   })
 
   it('should apply technology discount to building cost calculation', () => {
@@ -129,12 +157,12 @@ describe('Technologies', () => {
 
   it('should return unlocked building ids', () => {
     const ids = getUnlockedBuildingsIds(gameState)
-    expect(ids.every((id) => BUILDINGS.some((building) => building.id === id))).toBe(true)
+    expect(ids.every((id: string) => BUILDINGS.some((building) => building.id === id))).toBe(true)
   })
 
   it('should return unlocked job ids', () => {
     const ids = getUnlockedJobsIds(gameState)
-    expect(ids.every((id) => JOBS.some((job) => job.id === id))).toBe(true)
+    expect(ids.every((id: string) => JOBS.some((job) => job.id === id))).toBe(true)
   })
   it('should throw when job does not exist', () => {
     expect(() => isJobVisible(gameState, 'test')).toThrow('职业 test 不存在')

--- a/src/engine/technologies.ts
+++ b/src/engine/technologies.ts
@@ -101,7 +101,8 @@ function applyMultiplierEffect(
     return
   }
 
-  source[targetId] = (source[targetId] || 1) * value
+  // diffrent multipliers stock additively
+  source[targetId] = (source[targetId] || 1) + value
 }
 
 export function aggregateTechEffects(state: GameState): AggregatedTechEffects {
@@ -125,6 +126,17 @@ export function aggregateTechEffects(state: GameState): AggregatedTechEffects {
     const unlock = WORKSHOP_UNLOCKS.find((item) => item.id === unlockId)
     if (unlock?.effects) {
       allEffects.push(...unlock.effects)
+    }
+  }
+
+  for (const buildingId of getUnlockedBuildingsIds(state)) {
+    const building = BUILDINGS.find((item) => item.id === buildingId)
+    if (building?.Effects) {
+      const count = state.buildings[buildingId] || 0
+      for (const effect of building.Effects) {
+        const scaledEffect = { ...effect, value: effect.value * count }
+        allEffects.push(scaledEffect)
+      }
     }
   }
 
@@ -163,19 +175,6 @@ export function aggregateTechEffects(state: GameState): AggregatedTechEffects {
           }
         }
       }
-  }
-
-for (const building of BUILDINGS) {
-  const count = state.buildings[building.id] || 0
-  if (count <= 0 || !building.Effects) continue
-
-    for (const effect of building.Effects) {
-      if (effect.mode !== 'additive' || !effect.targetId) continue
-      if (!aggregated.jobProductionMultipliers[effect.targetId]) {
-        aggregated.jobProductionMultipliers[effect.targetId] = 1
-      }
-      aggregated.jobProductionMultipliers[effect.targetId] += effect.value * count
-    }
   }
 
   return aggregated

--- a/src/engine/technologies.ts
+++ b/src/engine/technologies.ts
@@ -155,7 +155,6 @@ export function aggregateTechEffects(state: GameState): AggregatedTechEffects {
   if (totalScienceAdd > 0) {
     aggregated.jobProductionMultipliers['scientist'] = (aggregated.jobProductionMultipliers['scientist'] || 1) * (1 + totalScienceAdd)
   }
-
   return aggregated
 }
 

--- a/src/engine/technologies.ts
+++ b/src/engine/technologies.ts
@@ -13,7 +13,11 @@ export interface AggregatedTechEffects {
   buildingCostMultipliers: Record<string, number>
   buildingProductionMultipliers: Record<string, number>
   jobProductionMultipliers: Record<string, number>
-  resourceLimitBonuses: Record<string, number>
+}
+
+interface EffectAccumulator {
+  additiveTotals: Record<string, number>
+  multiplierTotals: Record<string, number>
 }
 
 export function getTechnologyById(techId: string): Technology {
@@ -92,17 +96,39 @@ export function getVisibleTechnologiesIds(state: GameState): string[] {
   return TECHNOLOGIES.filter((technology) => isTechnologyVisible(state, technology)).map((tech) => tech.id)
 }
 
-function applyMultiplierEffect(
-  source: Record<string, number>,
-  targetId: string | undefined,
-  value: number,
+
+function addEffectContribution(
+  accumulator: EffectAccumulator,
+  effect: Effect,
+  occurrences: number = 1,
 ): void {
+  const targetId = effect.targetId
   if (!targetId) {
     return
   }
 
-  // diffrent multipliers stock additively
-  source[targetId] = (source[targetId] || 1) + value
+  if (effect.mode === 'additive') {
+    accumulator.additiveTotals[targetId] = (accumulator.additiveTotals[targetId] || 0) + effect.value * occurrences
+    return
+  }
+
+  accumulator.multiplierTotals[targetId] =
+    (accumulator.multiplierTotals[targetId] || 1) * effect.value ** occurrences
+}
+
+function finalizeEffects(accumulator: EffectAccumulator): Record<string, number> {
+  const targets = new Set([
+    ...Object.keys(accumulator.additiveTotals),
+    ...Object.keys(accumulator.multiplierTotals),
+  ])
+
+  const finalized: Record<string, number> = {}
+  for (const targetId of targets) {
+    finalized[targetId] =
+      (1 + (accumulator.additiveTotals[targetId] || 0)) * (accumulator.multiplierTotals[targetId] || 1)
+  }
+
+  return finalized
 }
 
 export function aggregateTechEffects(state: GameState): AggregatedTechEffects {
@@ -110,22 +136,64 @@ export function aggregateTechEffects(state: GameState): AggregatedTechEffects {
     buildingCostMultipliers: {},
     buildingProductionMultipliers: {},
     jobProductionMultipliers: {},
-    resourceLimitBonuses: {},
   }
 
-  const allEffects: Effect[] = []
+  const buildingCostEffects: EffectAccumulator = {
+    additiveTotals: {},
+    multiplierTotals: {},
+  }
+  const buildingProductionEffects: EffectAccumulator = {
+    additiveTotals: {},
+    multiplierTotals: {},
+  }
+  const jobProductionEffects: EffectAccumulator = {
+    additiveTotals: {},
+    multiplierTotals: {},
+  }
 
   for (const techId of state.researchedTechIds) {
     const technology = getTechnologyById(techId)
     if (technology.effects) {
-      allEffects.push(...technology.effects)
+      for (const effect of technology.effects) {
+        switch (effect.type) {
+          case 'building_cost':
+            addEffectContribution(buildingCostEffects, effect)
+            break
+          case 'building_production':
+            addEffectContribution(buildingProductionEffects, effect)
+            break
+          case 'job_production':
+            addEffectContribution(jobProductionEffects, effect)
+            break
+          default:
+            if (import.meta.env.DEV) {
+              console.warn(`未知科技效果类型: ${(effect as Effect).type}`)
+            }
+        }
+      }
     }
   }
 
   for (const unlockId of state.workshopUnlockIds) {
     const unlock = WORKSHOP_UNLOCKS.find((item) => item.id === unlockId)
     if (unlock?.effects) {
-      allEffects.push(...unlock.effects)
+      for (const effect of unlock.effects) {
+        switch (effect.type) {
+          case 'building_cost':
+            addEffectContribution(buildingCostEffects, effect)
+            break
+          case 'building_production':
+            addEffectContribution(buildingProductionEffects, effect)
+            break
+          case 'job_production':
+            addEffectContribution(jobProductionEffects, effect)
+            break
+          default:
+            if (import.meta.env.DEV) {
+              console.warn(`未知工坊效果类型: ${(effect as Effect).type}`)
+            }
+        }
+      }
     }
   }
 
@@ -134,48 +202,28 @@ export function aggregateTechEffects(state: GameState): AggregatedTechEffects {
     if (building?.Effects) {
       const count = state.buildings[buildingId] || 0
       for (const effect of building.Effects) {
-        const scaledEffect = { ...effect, value: effect.value * count }
-        allEffects.push(scaledEffect)
+        switch (effect.type) {
+          case 'building_cost':
+            addEffectContribution(buildingCostEffects, effect, count)
+            break
+          case 'building_production':
+            addEffectContribution(buildingProductionEffects, effect, count)
+            break
+          case 'job_production':
+            addEffectContribution(jobProductionEffects, effect, count)
+            break
+          default:
+            if (import.meta.env.DEV) {
+              console.warn(`未知建筑效果类型: ${(effect as Effect).type}`)
+            }
+        }
       }
     }
   }
 
-  for (const effect of allEffects) {
-      switch (effect.type) {
-        case 'building_cost': {
-          applyMultiplierEffect(
-            aggregated.buildingCostMultipliers,
-            effect.targetId,
-            effect.value,
-          )
-          break
-        }
-        case 'building_production': {
-          applyMultiplierEffect(
-            aggregated.buildingProductionMultipliers,
-            effect.targetId,
-            effect.value,
-          )
-          break
-        }
-        case 'job_production': {
-          applyMultiplierEffect(
-            aggregated.jobProductionMultipliers,
-            effect.targetId,
-            effect.value,
-          )
-          break
-        }
-        case 'resource_limit': {
-          throw new Error('Not implemented yet: resource_limit effect type aggregation')
-        }
-        default: {
-          if (import.meta.env.DEV) {
-            console.warn(`未知科技效果类型: ${(effect as Effect).type}`)
-          }
-        }
-      }
-  }
+  aggregated.buildingCostMultipliers = finalizeEffects(buildingCostEffects)
+  aggregated.buildingProductionMultipliers = finalizeEffects(buildingProductionEffects)
+  aggregated.jobProductionMultipliers = finalizeEffects(jobProductionEffects)
 
   return aggregated
 }
@@ -226,8 +274,7 @@ export function getVisibleJobsIds(state: GameState): string[] {
   return JOBS
     .filter((job) => isRequirementSatisfied(state, job.prerequisites || {}))
     .map((job) => job.id)
-
-  }
+}
 
 export function getUnlockedJobsIds(state: GameState): string[] {
   return getVisibleJobsIds(state)

--- a/src/engine/technologies.ts
+++ b/src/engine/technologies.ts
@@ -144,6 +144,18 @@ export function aggregateTechEffects(state: GameState): AggregatedTechEffects {
     }
   }
 
+ 
+  let totalScienceAdd = 0
+  for (const building of BUILDINGS) {
+    const count = state.buildings[building.id] || 0
+    if (count > 0 && building.effects?.scienceEfficiency) {
+      totalScienceAdd += building.effects.scienceEfficiency * count
+    }
+  }
+  if (totalScienceAdd > 0) {
+    aggregated.jobProductionMultipliers['scientist'] = (aggregated.jobProductionMultipliers['scientist'] || 1) * (1 + totalScienceAdd)
+  }
+
   return aggregated
 }
 

--- a/src/engine/technologies.ts
+++ b/src/engine/technologies.ts
@@ -165,17 +165,19 @@ export function aggregateTechEffects(state: GameState): AggregatedTechEffects {
       }
   }
 
- 
-  let totalScienceAdd = 0
-  for (const building of BUILDINGS) {
-    const count = state.buildings[building.id] || 0
-    if (count > 0 && building.effects?.scienceEfficiency) {
-      totalScienceAdd += building.effects.scienceEfficiency * count
+for (const building of BUILDINGS) {
+  const count = state.buildings[building.id] || 0
+  if (count <= 0 || !building.Effects) continue
+
+    for (const effect of building.Effects) {
+      if (effect.mode !== 'additive' || !effect.targetId) continue
+      if (!aggregated.jobProductionMultipliers[effect.targetId]) {
+        aggregated.jobProductionMultipliers[effect.targetId] = 1
+      }
+      aggregated.jobProductionMultipliers[effect.targetId] += effect.value * count
     }
   }
-  if (totalScienceAdd > 0) {
-    aggregated.jobProductionMultipliers['scientist'] = (aggregated.jobProductionMultipliers['scientist'] || 1) * (1 + totalScienceAdd)
-  }
+
   return aggregated
 }
 
@@ -225,7 +227,8 @@ export function getVisibleJobsIds(state: GameState): string[] {
   return JOBS
     .filter((job) => isRequirementSatisfied(state, job.prerequisites || {}))
     .map((job) => job.id)
-}
+
+  }
 
 export function getUnlockedJobsIds(state: GameState): string[] {
   return getVisibleJobsIds(state)

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -17,6 +17,10 @@ export interface Building {
   requiredBuildings?: string[]
   resourceLimitBonuses?: Record<string, number>
   populationCapBonus?: number
+  effects?: Partial<{ // 可扩展多种效果
+    scienceEfficiency: number 
+   
+  }>
 }
 
 export interface Job {
@@ -170,6 +174,7 @@ export const BUILDINGS: Building[] = [
     cost: { wood: 25, food: 100 },
     costGrowthMultiplier: 2,
     resourceLimitBonuses: { science: 200 },
+    effects: { scienceEfficiency: 0.1 },
   }
 ]
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -70,11 +70,9 @@ export interface WorkshopUnlock {
   effects?: Effect[]
 }
 
-export type GameEvent =
-  | { type: 'death'; dogId: string; dogName: string }
+export type GameEvent = { type: 'death'; dogId: string; dogName: string }
 
-export type GameLogType =
-  | 'death'
+export type GameLogType = 'death'
 
 export interface GameLog {
   id: string
@@ -105,7 +103,7 @@ export interface GameState {
   dogs: Dog[]
   populationGrowthProgress: number
   populationCap: number
-  
+
   isDomesticateEnabled: boolean
 
   tickCount: number
@@ -156,7 +154,7 @@ export const JOBS: Job[] = [
     prerequisites: {
       requiredBuildings: ['library'],
     },
-  }
+  },
 ]
 
 export const BUILDINGS: Building[] = [
@@ -196,14 +194,14 @@ export const BUILDINGS: Building[] = [
     costGrowthMultiplier: 2,
     resourceLimitBonuses: { science: 1500 },
     Effects: [
-    {
-      id: 'library-science-efficiency',
-      type: 'job_production',
-      targetId: 'scientist',
-      value: 0.1,
-      mode: 'additive',
-    },
-      ],
+      {
+        id: 'library-science-efficiency',
+        type: 'job_production',
+        targetId: 'scientist',
+        value: 0.1,
+        mode: 'additive',
+      },
+    ],
   },
   {
     id: 'workshop',
@@ -213,7 +211,7 @@ export const BUILDINGS: Building[] = [
     cost: { wood: 60 },
     costGrowthMultiplier: 1.8,
     requiredTechs: ['workshop_engineering'],
-  }
+  },
 ]
 
 export const TECHNOLOGIES: Technology[] = [

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -17,10 +17,7 @@ export interface Building {
   requiredBuildings?: string[]
   resourceLimitBonuses?: Record<string, number>
   populationCapBonus?: number
-  effects?: Partial<{ // 可扩展多种效果
-    scienceEfficiency: number 
-   
-  }>
+  Effects?: Effect[]
 }
 
 export interface Job {
@@ -198,7 +195,15 @@ export const BUILDINGS: Building[] = [
     cost: { wood: 25 },
     costGrowthMultiplier: 2,
     resourceLimitBonuses: { science: 1500 },
-    effects: { scienceEfficiency: 0.1 },
+    Effects: [
+    {
+      id: 'library-science-efficiency',
+      type: 'job_production',
+      targetId: 'scientist',
+      value: 0.1,
+      mode: 'additive',
+    },
+      ],
   },
   {
     id: 'workshop',

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -48,7 +48,6 @@ export interface Effect {
   type: EffectType
   mode: EffectMode
   targetId?: string
-  resourceId?: string
   value: number
 }
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -197,11 +197,8 @@ export const BUILDINGS: Building[] = [
     description: '解锁科技研究，提升科学产出并增加科学存储上限。',
     cost: { wood: 25 },
     costGrowthMultiplier: 2,
-<<<<<<< HEAD
-    resourceLimitBonuses: { science: 200 },
-    effects: { scienceEfficiency: 0.1 },
-=======
     resourceLimitBonuses: { science: 1500 },
+    effects: { scienceEfficiency: 0.1 },
   },
   {
     id: 'workshop',
@@ -211,7 +208,6 @@ export const BUILDINGS: Building[] = [
     cost: { wood: 60 },
     costGrowthMultiplier: 1.8,
     requiredTechs: ['workshop_engineering'],
->>>>>>> origin/develop
   }
 ]
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -13,6 +13,7 @@ import {
 } from '@/engine/technologies'
 import { min } from '@/engine/utils'
 
+
 const MAX_LOGS = 100
 
 function addLog(logs: GameLog[], log: Omit<GameLog, 'id'>): GameLog[] {


### PR DESCRIPTION
This pull request introduces a new settings panel for the game, reorganizes how game reset and save/load actions are accessed, and adds a new building effect that boosts scientist efficiency. The most important changes are grouped below:

**UI/UX Improvements:**

* Added a `SettingsPanel` component, accessible via a settings button in the header, which allows users to import/export saves and reset the game. The reset button was moved from the main UI into this panel for better organization. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R9-R11) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L50) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L98-R115) [[4]](diffhunk://#diff-450d51d921675969a34593bb6a8d460e1ee37b5344777b077c59cbcd5bf0f51fR1-R60)

**Game Mechanics Enhancements:**

* Extended the `Building` type to support an `effects` field for custom building effects, starting with `scienceEfficiency`.
* Updated the Laboratory building to provide a `scienceEfficiency` effect, increasing scientist productivity by 10% per lab.
* Modified the technology aggregation logic to sum up all `scienceEfficiency` effects from buildings and apply them as a multiplier to the scientist job's production.

**Minor Code Cleanups:**

* Removed an unused `resetGame` variable from `App.tsx`.
* Minor whitespace adjustment in `gameLoop.ts`.