### PR TITLE
feat(toggleable): add toggleable building system

### DIFF
--- a/src/components/BuildingPanel.tsx
+++ b/src/components/BuildingPanel.tsx
@@ -14,6 +14,13 @@ export function BuildingPanel() {
   const getBuildingCost = useGameStore((store) => store.getBuildingCost)
   const canBuildBuilding = useGameStore((store) => store.canBuildBuilding)
 
+  const setBuildingActiveCount = useGameStore((store) => store.setBuildingActiveCount)
+
+  const handleDelta = (buildingId: string, delta: number) => {
+    const current = gameState.buildingActiveCounts[buildingId] ?? 0
+    setBuildingActiveCount(buildingId, current + delta)
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -34,6 +41,9 @@ export function BuildingPanel() {
             const buildingCost = getBuildingCost(building.id)
             const canBuild = canBuildBuilding(building.id)
 
+            const activeCount = gameState.buildingActiveCounts[building.id] || 0
+            const isToggleable = building.isToggleable
+
             const costText = Object.entries(buildingCost)
               .map(([resourceId, cost]) => `${cost} ${resourceId}`)
               .join(' + ')
@@ -51,8 +61,19 @@ export function BuildingPanel() {
                   <Button size="sm" onClick={() => buildBuilding(building.id)} disabled={!canBuild}>
                     建造
                   </Button>
-                  <Badge variant="outline">已有 {count}</Badge>
+                  <Badge variant="outline">
+                    已有 {count}
+                    {isToggleable && ` / 启用 ${activeCount}`}
+                  </Badge>
                 </div>
+                  {isToggleable && (
+                  <div className="mt-3 flex gap-1.5">
+                    <Button size="sm" variant="outline" disabled={activeCount <= 0} onClick={() => handleDelta(building.id, -10)}>-10</Button>
+                    <Button size="sm" variant="outline" disabled={activeCount <= 0} onClick={() => handleDelta(building.id, -1)}>-1</Button>
+                    <Button size="sm" variant="outline" disabled={activeCount >= count} onClick={() => handleDelta(building.id, 1)}>+1</Button>
+                    <Button size="sm" variant="outline" disabled={activeCount >= count} onClick={() => handleDelta(building.id, 10)}>+10</Button>
+                  </div>
+                )}
               </div>
             )
           })}

--- a/src/engine/buildings.test.ts
+++ b/src/engine/buildings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { buildBuilding, canBuildBuilding, getBuildingCost, getBuildingById } from '@/engine/buildings'
+import { buildBuilding, canBuildBuilding, getBuildingCost, getBuildingById, setBuildingActiveCount } from '@/engine/buildings'
 import { BUILDINGS, type GameState } from '@/engine/types'
 import { createInitialGameState } from '@/engine/initialState'
 
@@ -102,6 +102,47 @@ describe('Buildings', () => {
     it('should throw when building prerequisites are not met in buildBuilding', () => {
       gameState.resourceCounts.wood = 1000
       expect(() => buildBuilding(gameState, 'workshop')).toThrow('尚未解锁')
+    })
+  })
+
+  describe('setBuildingActiveCount', () => {
+    it('should set activeCount within bounds', () => {
+      gameState.buildings.smelter = 3
+      gameState.buildingActiveCounts.smelter = 0
+
+      const next = setBuildingActiveCount(gameState, 'smelter', 2)
+      expect(next.buildingActiveCounts.smelter).toBe(2)
+    })
+
+    it('should clamp activeCount to ownedCount when count exceeds owned', () => {
+      gameState.buildings.smelter = 2
+      gameState.buildingActiveCounts.smelter = 0
+
+      const next = setBuildingActiveCount(gameState, 'smelter', 10)
+      expect(next.buildingActiveCounts.smelter).toBe(2)
+    })
+
+    it('should clamp activeCount to 0 when count is negative', () => {
+      gameState.buildings.smelter = 3
+      gameState.buildingActiveCounts.smelter = 2
+
+      const next = setBuildingActiveCount(gameState, 'smelter', -5)
+      expect(next.buildingActiveCounts.smelter).toBe(0)
+    })
+
+    it('should not affect non-toggleable buildings', () => {
+      gameState.buildings.barn = 3
+
+      const next = setBuildingActiveCount(gameState, 'barn', 3)
+      expect(next).toBe(gameState)
+    })
+
+    it('should not mutate original state', () => {
+      gameState.buildings.smelter = 2
+      gameState.buildingActiveCounts.smelter = 0
+
+      setBuildingActiveCount(gameState, 'smelter', 2)
+      expect(gameState.buildingActiveCounts.smelter).toBe(0)
     })
   })
 })

--- a/src/engine/buildings.ts
+++ b/src/engine/buildings.ts
@@ -76,3 +76,28 @@ export function buildBuilding(state: GameState, buildingId: string): GameState {
     buildings: newBuildings,
   }
 }
+
+export function setBuildingActiveCount(
+  state: GameState,
+  buildingId: string,
+  count: number
+): GameState {
+  // count: 将建筑设置为活跃的数量，必须小于等于拥有的数量
+  const building = getBuildingById(buildingId)
+
+  if (!building.isToggleable) return state  // WARNING: 只能设置可切换建筑的活跃数量
+
+  const ownedCount = state.buildings[buildingId] || 0
+
+  const clipped = Math.max(0, Math.min(ownedCount, count))
+
+  const nextBuildingActiveCounts = {
+    ...state.buildingActiveCounts,
+    [buildingId]: clipped,
+  }
+
+  return {
+    ...state,
+    buildingActiveCounts: nextBuildingActiveCounts,
+  }
+}

--- a/src/engine/constants.ts
+++ b/src/engine/constants.ts
@@ -5,7 +5,10 @@ export const INITIAL_RESOURCE_LIMITS = {
 	food: 10000,
 	wood: 1500,
 	stone: 1500,
-	dogpower: 50,
+	iron: 1000,
+	coal: 1000,
+	gold: 500,
+	dogpower: 100,
 	fur: 1500,
 }
 

--- a/src/engine/gameLoop.test.ts
+++ b/src/engine/gameLoop.test.ts
@@ -441,4 +441,67 @@ describe('Game Loop', () => {
       expect(springProduction.food).toBeCloseTo(0.23)
     })
   })
+
+  describe('Toggleable Buildings (Smelter)', () => {
+    it('should consume wood and stone and produce iron when smelter is active and resources are sufficient', () => {
+      gameState.buildings.smelter = 1
+      gameState.buildingActiveCounts.smelter = 1
+      gameState.resourceCounts.wood = 10
+      gameState.resourceCounts.stone = 10
+      gameState.resourceCounts.iron = 0
+
+      const { gameState: next } = tick(gameState)
+      expect(next.resourceCounts.wood).toBeCloseTo(9)
+      expect(next.resourceCounts.stone).toBeCloseTo(9)
+      expect(next.resourceCounts.iron).toBeCloseTo(1)
+    })
+
+    it('should not consume or produce when resources are insufficient', () => {
+      gameState.buildings.smelter = 1
+      gameState.buildingActiveCounts.smelter = 1
+      gameState.resourceCounts.wood = 0
+      gameState.resourceCounts.stone = 0
+      gameState.resourceCounts.iron = 0
+
+      const { gameState: next } = tick(gameState)
+      expect(next.resourceCounts.wood).toBe(0)
+      expect(next.resourceCounts.stone).toBe(0)
+      expect(next.resourceCounts.iron).toBe(0)
+    })
+
+    it('should not produce when activeCount is 0', () => {
+      gameState.buildings.smelter = 1
+      gameState.buildingActiveCounts.smelter = 0
+      gameState.resourceCounts.wood = 10
+      gameState.resourceCounts.stone = 10
+
+      const { gameState: next } = tick(gameState)
+      expect(next.resourceCounts.iron).toBe(0)
+    })
+
+    it('should scale linearly with activeCount', () => {
+      gameState.buildings.smelter = 3
+      gameState.buildingActiveCounts.smelter = 3
+      gameState.resourceCounts.wood = 10
+      gameState.resourceCounts.stone = 10
+      gameState.resourceCounts.iron = 0
+
+      const { gameState: next } = tick(gameState)
+      expect(next.resourceCounts.wood).toBeCloseTo(7)
+      expect(next.resourceCounts.stone).toBeCloseTo(7)
+      expect(next.resourceCounts.iron).toBeCloseTo(3)
+    })
+
+    it('should stop entire batch when only one resource is insufficient', () => {
+      gameState.buildings.smelter = 1
+      gameState.buildingActiveCounts.smelter = 1
+      gameState.resourceCounts.wood = 10
+      gameState.resourceCounts.stone = 0
+      gameState.resourceCounts.iron = 0
+
+      const { gameState: next } = tick(gameState)
+      expect(next.resourceCounts.wood).toBeCloseTo(10)
+      expect(next.resourceCounts.iron).toBe(0)
+    })
+  })
 })

--- a/src/engine/gameLoop.ts
+++ b/src/engine/gameLoop.ts
@@ -29,6 +29,10 @@ export function calculateProduction(gameState: GameState): Record<string, number
   })
 
   BUILDINGS.forEach((building) => {
+    // only calculate passive production from buildings here, toggleable ones 
+    // are handled separately in ToggleableBuildingConversions
+    if (building.isToggleable) return 
+
     const count = gameState.buildings[building.id] || 0
     const multiplier = buildingProductionMultipliers[building.id] || 1
 
@@ -100,6 +104,45 @@ export function calculateJobProduction(gameState: GameState): Record<string, num
   })
 
   return production
+}
+
+export function toggleableBuildingConversions(
+  state: GameState,
+  resourceCountsAfterProduction: Record<string, number>
+): Record<string, number> {
+  const next: Record<string, number> = { ...resourceCountsAfterProduction }
+
+  for (const building of BUILDINGS) {
+    if (!building.isToggleable) continue
+    const active = state.buildingActiveCounts[building.id] || 0
+    if (active <= 0) continue
+
+    const consumption = building.consumptionPerTick || {}
+    const totalConsumption: Record<string, number> = {}
+    for (const [resourceId, amount] of Object.entries(consumption)) {
+      totalConsumption[resourceId] = amount * active
+    }
+
+    let canPay = true
+    for (const [resourceId, need] of Object.entries(totalConsumption)) {
+      if ((next[resourceId] || 0) < need) {
+        canPay = false
+        break
+      }
+    }
+
+    if (!canPay) continue
+
+    for (const [resourceId, need] of Object.entries(totalConsumption)) {
+      next[resourceId] = (next[resourceId] || 0) - need
+    }
+
+    for (const [resourceId, amount] of Object.entries(building.productionPerTick || {})) {
+      next[resourceId] = (next[resourceId] || 0) + amount * active
+    }
+  }
+
+  return next
 }
 
 export function applyPopulationGrowth(
@@ -194,10 +237,12 @@ export function tick(state: GameState): { gameState: GameState; events: GameEven
     production[resourceId] = (production[resourceId] || 0) + amount
   }
 
-  const newResourceCounts: Record<string, number> = { ...state.resourceCounts }
+  let newResourceCounts: Record<string, number> = { ...state.resourceCounts }
   for (const [resourceId, amount] of Object.entries(production)) {
     newResourceCounts[resourceId] = (newResourceCounts[resourceId] || 0) + amount
   }
+
+  newResourceCounts = toggleableBuildingConversions(state, newResourceCounts)
 
   const populationUpdate = applyPopulationGrowth(state, newResourceCounts, nextPopulationCap)
 

--- a/src/engine/initialState.ts
+++ b/src/engine/initialState.ts
@@ -25,9 +25,18 @@ export function createInitialGameState(): GameState {
     buildings[building.id] = 0
   })
 
+  const buildingActiveCounts: Record<string, number> = {}
+  BUILDINGS.forEach((building) => {
+    // only initialize active count for toggleable buildings, others will be treated as always active
+    if (building.isToggleable) {
+      buildingActiveCounts[building.id] = 0
+    }
+  })
+
   return {
     resourceCounts: resources,
     buildings,
+    buildingActiveCounts,
     researchedTechIds: [],
     workshopUnlockIds: [],
     dogs: [],

--- a/src/engine/save.test.ts
+++ b/src/engine/save.test.ts
@@ -138,4 +138,30 @@ describe('Save System', () => {
     const loaded = loadGame()
     expect(loaded.workshopUnlockIds).toEqual(['wood_pickaxe'])
   })
+
+  it('should persist and reload buildingActiveCounts correctly', () => {
+    const state = createInitialGameState()
+    state.buildings.smelter = 2
+    state.buildingActiveCounts.smelter = 2
+    saveGame(state)
+
+    const loaded = loadGame()
+    expect(loaded.buildingActiveCounts.smelter).toBe(2)
+  })
+
+  it('should default buildingActiveCounts to initial value when missing from old save', () => {
+    const oldSave = {
+      version: '0.0.0',
+      resourceCounts: { food: 10 },
+      buildings: { smelter: 1 },
+      tickCount: 5,
+      lastTickTime: 12345,
+      // buildingActiveCounts intentionally absent
+    }
+    localStorage.setItem('puppies-game-save', JSON.stringify(oldSave))
+
+    const loaded = loadGame()
+    expect(loaded.buildingActiveCounts).toBeDefined()
+    expect(loaded.buildingActiveCounts.smelter ?? 0).toBe(0)
+  })
 })

--- a/src/engine/save.ts
+++ b/src/engine/save.ts
@@ -53,6 +53,7 @@ export function loadGame(): GameState {
     return {
       resourceCounts: mergeRecord(saveData.resourceCounts, INITIAL_GAME_STATE.resourceCounts),
       buildings: mergeRecord(saveData.buildings, INITIAL_GAME_STATE.buildings),
+      buildingActiveCounts: saveData.buildingActiveCounts ?? INITIAL_GAME_STATE.buildingActiveCounts,
       researchedTechIds,
       workshopUnlockIds,
       dogs: saveData.dogs ?? INITIAL_GAME_STATE.dogs,

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -13,6 +13,9 @@ export interface Building {
   costGrowthMultiplier: number
 
   productionPerTick?: Record<string, number>
+  isToggleable?: boolean
+  consumptionPerTick?: Record<string, number>
+
   requiredTechs?: string[]
   requiredBuildings?: string[]
   resourceLimitBonuses?: Record<string, number>
@@ -159,6 +162,7 @@ export interface Dog {
 export interface GameState {
   resourceCounts: Record<string, number>
   buildings: Record<string, number>
+  buildingActiveCounts: Record<string, number>
   researchedTechIds: string[]
   workshopUnlockIds: string[]
 
@@ -288,6 +292,18 @@ export const BUILDINGS: Building[] = [
     cost: { wood: 60 },
     costGrowthMultiplier: 1.8,
     requiredTechs: ['workshop_engineering'],
+  },
+  {
+    id: 'smelter',
+    name: '熔炉',
+    icon: '🔥',
+    description: '消耗木材与石料，生产铁矿。',
+    cost: { wood: 80, stone: 40 },
+    costGrowthMultiplier: 1.3,
+    isToggleable: true,
+    consumptionPerTick: { wood: 1, stone: 1 },
+    productionPerTick: { iron: 1 },
+    requiredTechs: ['mining'],
   },
 ]
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -22,7 +22,7 @@ import {
   setLeaderDog, 
   performExplore,
 } from '@/engine/actions'
-import { buildBuilding, canBuildBuilding, getBuildingCost } from '@/engine/buildings'
+import { buildBuilding, canBuildBuilding, getBuildingCost, setBuildingActiveCount } from '@/engine/buildings'
 import { saveGame, loadGame, resetGame } from '@/engine/save'
 import {
   canResearchTechnology,
@@ -81,6 +81,7 @@ interface GameStore {
   getVisibleWorkshopUnlockIds: () => string[]
   getCalendar: () => Calendar
   dispatchExplore: () => void
+  setBuildingActiveCount: (buildingId: string, count: number) => void
 
   addGameLog: (log: Omit<GameLog, 'id'>) => void
   markLogsAsRead: () => void
@@ -225,6 +226,12 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   getVisibleWorkshopUnlockIds: () => {
     return getVisibleWorkshopUnlockIds(get().gameState)
+  },
+
+  setBuildingActiveCount: (buildingId: string, count: number) => {
+    set((gameStore) => ({
+      gameState: setBuildingActiveCount(gameStore.gameState, buildingId, count),
+    }))
   },
 
   addGameLog: (log: Omit<GameLog, 'id'>) => {


### PR DESCRIPTION
This pull request introduces toggleable buildings to the game engine, UI, and save system, with the first such building being the "Smelter." Players can now control how many of these buildings are actively operating, which affects resource consumption and production. The changes also ensure that the active count is persisted in saves and properly tested. Additionally, resource limits for several resources have been increased.

**Toggleable Buildings Feature:**

* Added the `isToggleable` and `consumptionPerTick` properties to the `Building` type, and introduced the "Smelter" building as the first toggleable building (`src/engine/types.ts`) [[1]](diffhunk://#diff-be769f412da56da6f0abd5471e21c124526a712af1355da9d4b15327b403e824R16-R18) [[2]](diffhunk://#diff-be769f412da56da6f0abd5471e21c124526a712af1355da9d4b15327b403e824R296-R307).
* Implemented `setBuildingActiveCount` to control the number of active toggleable buildings, with clamping and immutability guarantees (`src/engine/buildings.ts`, `src/store/gameStore.ts`, `src/components/BuildingPanel.tsx`) [[1]](diffhunk://#diff-68af3eba171de273172c814dd747e379d66e61bb34a423a2308df2437d59cb71R79-R103) [[2]](diffhunk://#diff-1d7fa1ad6fa56a5a2dd586809b159625b9f0f74c924c28b630f362fa2c7496f5L25-R25) [[3]](diffhunk://#diff-1d7fa1ad6fa56a5a2dd586809b159625b9f0f74c924c28b630f362fa2c7496f5R84) [[4]](diffhunk://#diff-1d7fa1ad6fa56a5a2dd586809b159625b9f0f74c924c28b630f362fa2c7496f5R231-R236) [[5]](diffhunk://#diff-bdb653c029da194223818a0293f52fcc2438df2103a54b64102dce82120d8458R17-R23) [[6]](diffhunk://#diff-bdb653c029da194223818a0293f52fcc2438df2103a54b64102dce82120d8458R44-R46) [[7]](diffhunk://#diff-bdb653c029da194223818a0293f52fcc2438df2103a54b64102dce82120d8458L54-R76).
* Updated the UI to allow users to adjust the active count of toggleable buildings, showing both owned and active counts and providing increment/decrement buttons (`src/components/BuildingPanel.tsx`).

**Game Logic and Persistence:**

* Modified the game loop to process resource consumption and production for toggleable buildings based on their active counts (`src/engine/gameLoop.ts`) [[1]](diffhunk://#diff-817469921effa92ddadf246323437eaa6413088f531a0c87a4772c3075c18cd1R32-R35) [[2]](diffhunk://#diff-817469921effa92ddadf246323437eaa6413088f531a0c87a4772c3075c18cd1R109-R147) [[3]](diffhunk://#diff-817469921effa92ddadf246323437eaa6413088f531a0c87a4772c3075c18cd1L197-R246).
* Updated the initial game state and save/load logic to handle `buildingActiveCounts`, including migration for old saves (`src/engine/initialState.ts`, `src/engine/save.ts`, `src/engine/save.test.ts`) [[1]](diffhunk://#diff-96f769af14e5756e23a3dab24604ddfaa71a77868adc865f0e31d51979dac316R28-R39) [[2]](diffhunk://#diff-a2e54784cf2883f51dd45a62bd9c1ce9931e3b614efc20240e97d13592da4c22R56) [[3]](diffhunk://#diff-f5b9a3209fd450c893ea2d772b16bd74d8f6155e79a69fa876218e7a00391e42R141-R166).

**Testing and Resource Limits:**

* Added comprehensive tests for toggleable building behavior, including the smelter's production logic and active count management (`src/engine/buildings.test.ts`, `src/engine/gameLoop.test.ts`) [[1]](diffhunk://#diff-b8992ae9e418ecdf217bb49f2fe61f226618b83f5c4e18c68aa95c714165cc15R107-R147) [[2]](diffhunk://#diff-f64c68fa2a2a04c9c263714f7635f8be94085c47982eac705476978a48c280f9R444-R506).
* Increased resource limits for iron, coal, gold, and dogpower (`src/engine/constants.ts`).